### PR TITLE
chore: simplify build types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2.7
+
+- Optimized type validation logic.
+
 ## v4.2.5
 
 - Improved support for objects with union values.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mockemon",
-  "version": "4.2.6",
+  "version": "4.2.7",
   "repository": "https://github.com/Glinkis/mockemon.git",
   "author": "Victor Glindås <glinkis@gmail.com>",
   "license": "MIT",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -21,10 +21,10 @@ type Overrideable<TValue> = {
 type Build<TContext, TValue> = (config: TContext) => TValue;
 
 type BuildInput<TValue, TOverride> = //
-  // If the override is a subset of a compatible set of the original value.
-  Exclude<TValue, TOverride> extends Extract<TValue, TOverride> //
+  // If the override is a subset of the original value.
+  TOverride extends TValue //
     ? TOverride
-    : // If the override is any subset of the original value.
+    : // If the override keys are a subset of the keys in the original value.
       keyof TOverride extends keyof TValue
       ? TOverride
       : TValue;

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -30,19 +30,15 @@ type BuildInput<TValue, TOverride> = //
       : TValue;
 
 type BuildOutput<TValue, TOverride> =
-  // If the overrides are identical to the value.
+  // If the override is identical to the original value.
   TValue extends TOverride
-    ? // Just use the value.
-      TValue
-    : // If the overrides are a subset of the value.
-      keyof TValue extends keyof TOverride
-      ? // We need to merge in the overrides
+    ? TValue
+    : // If the override keys are a subset of the keys in the original value.
+      keyof TOverride extends keyof TValue
+      ? // We need to merge in the overrides.
         TValue & TOverride
-      : // If the overrides are a subset of the value.
-        keyof TOverride extends keyof TValue
-        ? TValue & TOverride
-        : // If the overrides don't match the value at all, it's invalid.
-          never;
+      : // If the overrides don't match the value at all, it's invalid.
+        never;
 
 type CreateMockBuilder<TConfig extends Configuration, TContext = TConfig["context"]> = {
   <TValue>(build: Build<TContext, TValue>): {

--- a/tests/builder.test.ts
+++ b/tests/builder.test.ts
@@ -435,9 +435,9 @@ describe("validation", () => {
     type Shape1 = { a: string; b: string };
     const build1 = createMockBuilder((): Shape1 | null => null);
 
-    // @ts-expect-error - Missing 'a' property.
-    build1({ a: "a" });
     // @ts-expect-error - Missing 'b' property.
+    build1({ a: "a" });
+    // @ts-expect-error - Missing 'a' property.
     build1(() => ({ b: "b" }));
 
     type Shape2 = { c: string };


### PR DESCRIPTION
This PR simplifies two type comparisons:
1. Replace first ternary of `BuildInput` with direct comparison to reduce complexity
_The expression contained double validation of type intersection and could be directly simplified to the form of `T extends U`._
2. Use a single ternary for key subset validation in `BuildOutput`
_Because `BuildInput` ensures `TOverride` is a subset of `TValue` and is always used in conjunction with `BuildOutput`, we can skip the same check in `BuildOutput`._

I will try to explain my reasoning more formally below to make it easier to see if there's a flaw in my logic.

### BuildInput reasoning
---
The following definitions will be used to make the explanation easier to read:
> A = TValue
> B = TOverride

This condition:
```ts
// If the override is a subset of a compatible set of the original value.
Exclude<TValue, TOverride> extends Extract<TValue, TOverride> //
```
Could be represented as:
(A ∖ B) ⊆ (A ∩ B)

Plainly: all elements in A that are not in B are a subset of the elements that are common to both A and B.

Since all elements in A but not in B cannot simultaneously also be in B, it means there are no such elements. Thus, we can replace (A ∩ B) with the empty set:
A ∖ B = ∅

Inverting this to a positive statement instead leaves us with: all elements in A are a subset of all elements in B:
A ⊆ B

That means we should be able to check if `TValue` is a subset of `TOverride` by comparing them directly:
```ts
  // If the original value is a subset of the override
  TValue extends TOverride
```

### BuildOutput reasoning
---
I will use the following definitions to make the explanation easier to read:

> A = keyof TValue
> B = keyof TOverride
> V = TValue
> O = TOverride

Original:
```ts
// If the overrides are identical to the value.
TValue extends TOverride
  ? // Just use the value.
    TValue
  : // If the overrides are a subset of the value.
    keyof TValue extends keyof TOverride
    ? // We need to merge in the overrides
      TValue & TOverride
    : // If the overrides are a subset of the value.
      keyof TOverride extends keyof TValue
      ? TValue & TOverride
      : // If the overrides don't match the value at all, it's invalid.
        never;
```

The first ternary condition simply reads:
V ⊆ O

However, since `BuildInput` and `BuildOutput` are always used together and `BuildInput` ensures O is a subset of V, we know O cannot be a proper superset of V. Thus, this line effectively checks whether V = O, as the comment also points out.

Moving on, let's combine the two `keyof` conditions into a single OR statement to make them easier to work with. This is possible because the ternaries lead to the same result when either is true or when both are false. The statement then becomes:
(A ⊆ B) ∨ (B ⊂ A)

In isolation, this statement is optimal, but we already know B can never be a proper superset of A due to type validation in the `keyof` ternary of `BuildInput`.

Since A is never a proper subset of B, that means we can remove A ⊆ B if we check whether B is _any subset_ of A:
B ⊆ A

```ts
type BuildOutput<TValue, TOverride> =
  // If the override is identical to the original value.
  TValue extends TOverride
    ? TValue
    : // If the override keys are a subset of the keys in the original value.
      keyof TOverride extends keyof TValue
      ? // We need to merge in the overrides.
        TValue & TOverride  
      : // If there is no intersection between overrides and the original value, it's invalid.
        never;
```